### PR TITLE
add EMBOSS build

### DIFF
--- a/emboss/build.sh
+++ b/emboss/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+arch=x86_64
+pkg=emboss
+version=6.6.0
+build_deps="libc6-dev zlib1g-dev libncurses5-dev"
+urls="
+ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-${version}.tar.gz
+"
+
+apt-get -qq update &&
+    apt-get install --no-install-recommends -y $build_deps &&
+    mkdir /build &&
+    cd /build &&
+
+    ( for url in $urls; do
+        wget "$url" || false || exit
+    done ) &&
+
+    mkdir -p $HOME/bin/${arch}/ /build/dest/bin /build/dest/lib &&
+    tar xfvz EMBOSS-${version}.tar.gz &&
+    cd EMBOSS-${version} &&
+    ./configure --prefix /build/dest --without-x && make && make install &&
+    tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C /build/dest .
+

--- a/emboss/build.sh
+++ b/emboss/build.sh
@@ -19,6 +19,7 @@ apt-get -qq update &&
     mkdir -p $HOME/bin/${arch}/ /build/dest/bin /build/dest/lib &&
     tar xfvz EMBOSS-${version}.tar.gz &&
     cd EMBOSS-${version} &&
-    ./configure --prefix /build/dest --without-x && make && make install &&
+    ORIGIN='$ORIGIN' &&
+    export ORIGIN &&
+    LDFLAGS='-Wl,-rpath,$${ORIGIN}/../lib' ./configure --prefix /build/dest --without-x && make && make install &&
     tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C /build/dest .
-


### PR DESCRIPTION
## Add build instructions for EMBOSS

To get it running you need to:
- export LD_LIBRARY_PATH=/home/user/emboss-6.6.0-Linux-x86_64/lib/:$LD_LIBRARY_PATH
- export EMBOSS_ACDROOT=/home/user/emboss-6.6.0-Linux-x86_64/share/EMBOSS/acd
