### PR TITLE
Add perl libGD modifications

### DIFF
--- a/perlgd/build.sh
+++ b/perlgd/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+arch=x86_64
+pkg=perlgd
+version=2.56
+build_deps=""
+urls="
+https://cpan.metacpan.org/authors/id/L/LD/LDS/GD-${version}.tar.gz
+"
+
+build=/build/
+
+apt-get -qq update &&
+    apt-get install --no-install-recommends -y $build_deps &&
+    mkdir ${build} &&
+    cd ${build} &&
+
+    ( for url in $urls; do
+        wget "$url" || false || exit
+    done ) &&
+
+    tar xfz GD-${version}.tar.gz &&
+    pwd &&
+    chmod ugo+w GD-${version}/bdf_scripts/* &&
+    tar zcf /host/GD-${version}.tar.gz GD-${version}/


### PR DESCRIPTION
Perl's GD library fails to compiled and install automatically due to the presence of unwritable files in the `bdf_scripts/` folder. This is an issue known to upstream: https://rt.cpan.org/Public/Bug/Display.html?id=99901 but left unfixed despite rendering the package uninstallable from source.

Thus, this docker build script exists to make those scripts writeable and thus render the package installable, so it can be used in the circos installation definition. https://github.com/galaxyproject/tools-iuc/issues/77
