### PR TITLE
UCSC recipe fix and docker image pinning

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,14 +1,14 @@
-./build ubuntu atlas
-./build ubuntu bcftools
-./build ubuntu emboos
-./build ubuntu jellyfish
-./build ubuntu kraken
-./build ubuntu ngninx
-./build ubuntu openms
-./build ubuntu pkiss
-./build ubuntu rnashapes
-./build ubuntu samtools
-./build ubuntu tpp
-./build ubuntu ucsc
+./build ubuntu:12.04 atlas
+./build ubuntu:12.04 bcftools
+./build ubuntu:12.04 emboos
+./build ubuntu:12.04 jellyfish
+./build ubuntu:12.04 kraken
+./build ubuntu:12.04 ngninx
+./build ubuntu:12.04 openms
+./build ubuntu:12.04 pkiss
+./build ubuntu:12.04 rnashapes
+./build ubuntu:12.04 samtools
+./build ubuntu:12.04 tpp
+./build ubuntu:12.04 ucsc
 
 python build.py --quiet tbl2asn

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,14 +1,14 @@
-./build ubuntu:12.04 atlas
-./build ubuntu:12.04 bcftools
-./build ubuntu:12.04 emboos
-./build ubuntu:12.04 jellyfish
-./build ubuntu:12.04 kraken
-./build ubuntu:12.04 ngninx
-./build ubuntu:12.04 openms
-./build ubuntu:12.04 pkiss
-./build ubuntu:12.04 rnashapes
-./build ubuntu:12.04 samtools
-./build ubuntu:12.04 tpp
-./build ubuntu:12.04 ucsc
+./build debian:squeeze atlas
+./build debian:squeeze bcftools
+./build debian:squeeze emboos
+./build debian:squeeze jellyfish
+./build debian:squeeze kraken
+./build debian:squeeze ngninx
+./build debian:squeeze openms
+./build debian:squeeze pkiss
+./build debian:squeeze rnashapes
+./build debian:squeeze samtools
+./build debian:squeeze tpp
+./build debian:squeeze ucsc
 
 python build.py --quiet tbl2asn

--- a/ucsc/build.sh
+++ b/ucsc/build.sh
@@ -8,7 +8,7 @@ http://hgdownload.soe.ucsc.edu/admin/jksrc.v${version}.zip
 "
 
 build=/build
-dest="${pkg}_${arch}_${version}"
+dest="build/${pkg}_${arch}_${version}"
 
 apt-get -qq update &&
     apt-get install --no-install-recommends -y $build_deps &&
@@ -37,4 +37,4 @@ apt-get -qq update &&
                 ;;
         esac
     done
-    tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C ${build}/${dest} .
+    tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C ${build}/${dest}/../ .

--- a/ucsc/build.sh
+++ b/ucsc/build.sh
@@ -8,7 +8,8 @@ http://hgdownload.soe.ucsc.edu/admin/jksrc.v${version}.zip
 "
 
 build=/build
-dest="build/${pkg}_${arch}_${version}"
+build_identifier="${pkg}-${version}-Linux-${arch}"
+dest="build/${build_identifier}"
 
 apt-get -qq update &&
     apt-get install --no-install-recommends -y $build_deps &&
@@ -37,4 +38,4 @@ apt-get -qq update &&
                 ;;
         esac
     done
-    tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C ${build}/${dest}/../ .
+    tar zcf /host/${build_identifier}.tar.gz -C ${build}/${dest}/../ .

--- a/ucsc/build.sh
+++ b/ucsc/build.sh
@@ -8,6 +8,7 @@ http://hgdownload.soe.ucsc.edu/admin/jksrc.v${version}.zip
 "
 
 build=/build
+dest="${pkg}_${arch}_${version}"
 
 apt-get -qq update &&
     apt-get install --no-install-recommends -y $build_deps &&
@@ -18,7 +19,7 @@ apt-get -qq update &&
         wget "$url" || false || exit
     done ) &&
 
-    mkdir -p $HOME/bin/${arch}/ ${build}/dest/bin ${build}/dest/lib &&
+    mkdir -p $HOME/bin/${arch}/ ${build}/${dest}/bin ${build}/${dest}/lib &&
     unzip jksrc.v${version}.zip &&
     cd kent/src/lib/ &&
     make &&
@@ -27,13 +28,13 @@ apt-get -qq update &&
     ORIGIN='$ORIGIN'
     export COPT ORIGIN &&
     find . -type d -maxdepth 1 -mindepth 1 -exec make -C '{}' \; &&
-    mv $HOME/bin/${arch}/* ${build}/dest/bin/ &&
-    for lib in $(ldd ${build}/dest/bin/faToTwoBit | grep -o '=> /[^ ]*' | sed 's/=> //g'); do
+    mv $HOME/bin/${arch}/* ${build}/${dest}/bin/ &&
+    for lib in $(ldd ${build}/${dest}/bin/faToTwoBit | grep -o '=> /[^ ]*' | sed 's/=> //g'); do
         case $lib in
             */libcrypto.so*|*/libgcc_s.so*|*/libmysqlclient.so*|*/libssl.so*|*/libstdc++.so*)
                 echo "including $lib"
-                cp $lib ${build}/dest/lib/
+                cp $lib ${build}/${dest}/lib/
                 ;;
         esac
     done
-    tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C ${build}/dest .
+    tar zcf /host/${pkg}-${version}-Linux-${arch}.tar.gz -C ${build}/${dest} .


### PR DESCRIPTION
This contains two fixes (which should've been separate PRs buuuut whatever)
- pin packages to 12.04, this is specific to my jenkins server which has a tiny SSD and apparently the first time docker sees a name like `ubuntu`, it will pull all of the tags, chewing through the last 6Gb of disk available. By pulling only a single tag, we only use up the 500 mb required for that image.
- UCSC is updated to move files into a single directory. This intentionally breaks the previous version (see #23) as no one else is using this package yet, and we might as well do it right from the start.
