### PR TITLE
update package description

### DIFF
--- a/R/build.sh
+++ b/R/build.sh
@@ -9,17 +9,17 @@ else
 fi
 
 if [ -z $3 ] ; then
-    version=3.2.0
+    version=3.2.1
 else
     version=$3
 fi
 
-build_deps="libc6-dev zlib1g-dev tcl-dev tk-dev libblas-dev liblapack-dev libcairo2-dev libpng12-dev libtiff4-dev libjpeg-dev libreadline-dev default-jre"
+build_deps="libc6-dev zlib1g-dev tcl-dev tk-dev libblas-dev liblapack-dev libcairo2-dev libpng12-dev libtiff4-dev libjpeg-dev libreadline-dev"
 urls="http://cran.rstudio.com/src/base/R-3/$pkg-$version.tar.gz"
 
 apt-get -qq update &&
     apt-get install --no-install-recommends -y $build_deps &&
-    mkdir /build &&
+    mkdir -p /build/dest/lib/ &&
     cd /build &&
 
     ( for url in $urls; do
@@ -34,8 +34,6 @@ apt-get -qq update &&
     export LDFLAGS='-Wl,-rpath,\$$ORIGIN/../lib' &&
     ./configure --with-readline=yes \
                 --with-x=no \
-                --with-blas \
-                --with-lapack \
                 --with-cairo \
                 --with-libpng \
                 --enable-R-shlib \
@@ -49,7 +47,11 @@ apt-get -qq update &&
     sed -i 's#/build/dest#$(R_ROOT_DIR)#g' /build/dest/lib/R/etc/Makeconf &&
     cp /usr/lib/libgfortran* /build/dest/lib/ &&
     cp /usr/lib/libgomp* /build/dest/lib/ &&
-    cp /usr/lib/libblas.so.3gf /build/dest/lib &&
+    cp /usr/lib/libblas* /build/dest/lib -R &&
+    cp /usr/lib/libcairo* /build/dest/lib &&
+    cp /usr/lib/libreadline* /build/dest/lib &&
+    cp /usr/lib/liblapack* /build/dest/lib &&
+    cp /usr/lib/libpng* /build/dest/lib &&
     cd /build/dest/lib &&
     ln -s libgfortran.so.3 libgfortran.so &&
     ln -s libgomp.so.1.0.0 libgomp.so &&

--- a/R/build.sh
+++ b/R/build.sh
@@ -47,7 +47,7 @@ apt-get -qq update &&
     sed -i 's#/build/dest#$(R_ROOT_DIR)#g' /build/dest/lib/R/etc/Makeconf &&
     cp /usr/lib/libgfortran* /build/dest/lib/ &&
     cp /usr/lib/libgomp* /build/dest/lib/ &&
-    cp /usr/lib/libblas* /build/dest/lib -R &&
+    cp -R /usr/lib/libblas* /build/dest/lib &&
     cp /usr/lib/libcairo* /build/dest/lib &&
     cp /usr/lib/libreadline* /build/dest/lib &&
     cp /usr/lib/liblapack* /build/dest/lib &&


### PR DESCRIPTION
Hi @davebx,

I was not able to use the new R-3.2 packages. I always get a libblas error stating that FORTRAN_1_4 symbol was not found. I do no get these error with your old packages R < 3.2. Also when I compare the both packages R3.1 vs R3.2 it seems that R3.1 contains a lot more shared-object files, including cairo, Rblas.so, Ratlas.so ...

If you remove `--with-blas & --with-lapack` you get the Ratlas.so file back and installation of DESeq2 works again for me. Also please see this mailing list thread: http://dev.list.galaxyproject.org/Installing-Cairo-into-Gakaxy-td4667769.html

While I'm not sure this new build will fix the cairo issue, probably not, it fixes at least the blas, lapack issue. And a rebuild is needed to get this package in: https://github.com/galaxyproject/tools-iuc/pull/20

Thanks,
Bjoern
