### PR TITLE
Check for new versions of wheels in PyPI

### DIFF
--- a/starforge/cli.py
+++ b/starforge/cli.py
@@ -85,3 +85,4 @@ def starforge(ctx, debug, config_file):
     """
     set_debug(debug)
     ctx.config_file = config_file
+    ctx.debug = debug

--- a/starforge/commands/cmd_wheel_updates.py
+++ b/starforge/commands/cmd_wheel_updates.py
@@ -68,8 +68,11 @@ def cli(ctx, wheels_config, wheel):
     for wheel, wheel_config in wheel_configs:
         if wheel_config.pinned:
             continue
+        req = wheel
+        if wheel_config.version_spec:
+            req += wheel_config.version_spec
         inst_req = InstallRequirement.from_line(
-            wheel, None, isolated=False, wheel_cache=None)
+            req, None, isolated=False, wheel_cache=None)
         inst_req.satisfied_by = Distribution(
             wheels_config, None, wheel, wheel_config.version, None, None, None)
         try:

--- a/starforge/commands/cmd_wheel_updates.py
+++ b/starforge/commands/cmd_wheel_updates.py
@@ -1,0 +1,190 @@
+"""
+"""
+from __future__ import absolute_import
+
+import logging
+
+from pip.index import PackageFinder
+from pip.download import PipSession
+from pip.req import InstallRequirement
+from pip.index import PyPI
+from pip.exceptions import BestVersionAlreadyInstalled
+from pip._vendor.packaging.version import parse as parse_version
+from pkg_resources import Distribution, DistributionNotFound
+import click
+
+from ..io import debug, info, fatal
+from ..cli import pass_context
+from ..util import xdg_config_file
+from ..config.wheels import WheelConfigManager
+
+
+@click.command('wheel_updates')
+@click.option('--wheels-config',
+              default=xdg_config_file(name='wheels.yml'),
+              type=click.Path(file_okay=True,
+                              writable=False,
+                              resolve_path=True),
+              help='Path to wheels config file')
+@click.argument('wheel', nargs=-1,)
+@pass_context
+def cli(ctx, wheels_config, wheel):
+    """ Determine what wheels have updates available.
+    """
+    wheels = wheel
+    wheel_cfgmgr = WheelConfigManager.open(ctx.config, wheels_config)
+
+    # Set log level for pip logging
+    if ctx.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    session = PipSession(
+        cache=None,
+        retries=None,
+        insecure_hosts=[]
+    )
+    finder = PackageFinder(
+        find_links=[],
+        index_urls=[PyPI.simple_url],
+        session=session
+    )
+
+    if not wheels:
+        wheel_configs = wheel_cfgmgr
+    else:
+        wheel_configs = []
+        for wheel in wheels:
+            try:
+                wheel_config = wheel_cfgmgr.get_wheel_config(wheel)
+            except KeyError:
+                fatal('Package not found in %s: %s', wheels_config, wheel)
+            if wheel_config.pinned:
+                fatal("%s version is pinned to %s",
+                      wheel, wheel_config.version)
+            wheel_configs.append((wheel, wheel_config))
+
+    for wheel, wheel_config in wheel_configs:
+        if wheel_config.pinned:
+            continue
+        inst_req = InstallRequirement.from_line(
+            wheel, None, isolated=False, wheel_cache=None)
+        inst_req.satisfied_by = Distribution(
+            wheels_config, None, wheel, wheel_config.version, None, None, None)
+        try:
+            # newest is actually a distlib Version object
+            newest = finder.find_newest_version(inst_req, True)
+            info('%s %s', wheel, newest)
+        except BestVersionAlreadyInstalled:
+            debug("%s %s in wheels config is the newest version",
+                  wheel, wheel_config.version)
+
+
+# This is mostly the find_requirement method from pip.index.PackageFinder in
+# pip 8, but that method only returns the location. We need the version, not
+# the link.  Modifications are present to support pip < 8. This works on at
+# least pip 7.1.2, I have not tested other versions.
+def find_requirement(self, req, upgrade):
+    """Try to find a Link matching req
+
+    Expects req, an InstallRequirement and upgrade, a boolean
+    Returns a Link if found,
+    Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
+    """
+    logger = logging.getLogger(__name__)
+
+    try:
+        all_candidates = self.find_all_candidates(req.name)
+    except AttributeError:
+        all_candidates = self._find_all_versions(req.name)
+
+    # Filter out anything which doesn't match our specifier
+    _versions = set(
+        req.specifier.filter(
+            # We turn the version object into a str here because otherwise
+            # when we're debundled but setuptools isn't, Python will see
+            # packaging.version.Version and
+            # pkg_resources._vendor.packaging.version.Version as different
+            # types. This way we'll use a str as a common data interchange
+            # format. If we stop using the pkg_resources provided specifier
+            # and start using our own, we can drop the cast to str().
+            [str(c.version) for c in all_candidates],
+            prereleases=(
+                self.allow_all_prereleases
+                if self.allow_all_prereleases else None
+            ),
+        )
+    )
+    applicable_candidates = [
+        # Again, converting to str to deal with debundling.
+        c for c in all_candidates if str(c.version) in _versions
+    ]
+
+    applicable_candidates = self._sort_versions(applicable_candidates)
+
+    if req.satisfied_by is not None:
+        installed_version = parse_version(req.satisfied_by.version)
+    else:
+        installed_version = None
+
+    if installed_version is None and not applicable_candidates:
+        logger.critical(
+            'Could not find a version that satisfies the requirement %s '
+            '(from versions: %s)',
+            req,
+            ', '.join(
+                sorted(
+                    set(str(c.version) for c in all_candidates),
+                    key=parse_version,
+                )
+            )
+        )
+
+        raise DistributionNotFound(
+            'No matching distribution found for %s' % req
+        )
+
+    best_installed = False
+    if installed_version and (
+            not applicable_candidates or
+            applicable_candidates[0].version <= installed_version):
+        best_installed = True
+
+    if not upgrade and installed_version is not None:
+        if best_installed:
+            logger.debug(
+                'Existing installed version (%s) is most up-to-date and '
+                'satisfies requirement',
+                installed_version,
+            )
+        else:
+            logger.debug(
+                'Existing installed version (%s) satisfies requirement '
+                '(most up-to-date version is %s)',
+                installed_version,
+                applicable_candidates[0].version,
+            )
+        return None
+
+    if best_installed:
+        # We have an existing version, and its the best version
+        logger.debug(
+            'Installed version (%s) is most up-to-date (past versions: '
+            '%s)',
+            installed_version,
+            ', '.join(str(c.version) for c in applicable_candidates) or
+            "none",
+        )
+        raise BestVersionAlreadyInstalled
+
+    selected_candidate = applicable_candidates[0]
+    logger.debug(
+        'Using version %s (newest of versions: %s)',
+        selected_candidate.version,
+        ', '.join(str(c.version) for c in applicable_candidates)
+    )
+    return selected_candidate.version
+
+
+PackageFinder.find_newest_version = find_requirement

--- a/starforge/config/wheels.py
+++ b/starforge/config/wheels.py
@@ -30,6 +30,7 @@ class WheelConfig(object):
         self.build_args = config.get('build_args', 'bdist_wheel')
         self.buildpy = config.get('buildpy', 'python')
         self.pinned = config.get('pinned', False)
+        self.version_spec = config.get('version_specifier', None)
         if not purepy:
             default_imageset = DEFAULT_C_IMAGESET
         else:

--- a/starforge/config/wheels.py
+++ b/starforge/config/wheels.py
@@ -29,6 +29,7 @@ class WheelConfig(object):
         self.force_pythons = config.get('force_pythons', None)
         self.build_args = config.get('build_args', 'bdist_wheel')
         self.buildpy = config.get('buildpy', 'python')
+        self.pinned = config.get('pinned', False)
         if not purepy:
             default_imageset = DEFAULT_C_IMAGESET
         else:

--- a/starforge/io.py
+++ b/starforge/io.py
@@ -15,7 +15,7 @@ def debug(message, *args):
     if args:
         message = message % args
     if DEBUG:
-        click.echo(message)
+        click.echo(message, err=True)
 
 
 def info(message, *args, **kwargs):

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -12,6 +12,7 @@ packages:
         version: 0.23
     mercurial:
         version: 3.4.2
+        pinned: true
         insert_setuptools: true
     numpy:
         version: 1.9.2
@@ -34,6 +35,7 @@ packages:
         insert_setuptools: true
     pysam:
         version: 0.8.3+gx1
+        pinned: true
         src:
             - https://github.com/dannon/pysam/archive/flexible_bam_index_naming.tar.gz
         # https://github.com/pysam-developers/pysam/issues/164
@@ -116,6 +118,7 @@ purepy_packages:
     pbr:
         version: 1.8.0
     pip:
+        # pip is not pinned - we need to know when 8.0 is released, but when it is, we need to generate a new gx version
         version: 8.0.0.dev0+gx1
         src:
             - https://github.com/natefoo/pip/archive/linux-wheels.tar.gz
@@ -148,6 +151,7 @@ purepy_packages:
         insert_setuptools: true
     WebError:
         version: 0.10.3
+        pinned: true
     WebHelpers:
         version: 1.3
     WebOb:
@@ -158,5 +162,6 @@ purepy_packages:
             - https://bitbucket.org/natefoo/wheel/get/795314b825f9.tar.gz
         prebuild: sed -i -e 's/__version__ = "0\.26\.0"/__version__ = "0.26.0+gx1"/' ${SRC_ROOT}/wheel/__init__.py
     Whoosh:
-        version: 2.4.1
+        version: 2.4.1+gx1
+        pinned: true
         prebuild: sed -i -e 's/self\.results\.docterms\[self\.docnum\]/self.results.docterms.get(self.docnum, [])/' ${SRC_ROOT}/src/whoosh/searching.py && sed -i -e 's/versionstring()/"2.4.1+gx1"/' ${SRC_ROOT}/setup.py

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -12,7 +12,7 @@ packages:
         version: 0.23
     mercurial:
         version: 3.4.2
-        pinned: true
+        version_specifier: <3.5
         insert_setuptools: true
     numpy:
         version: 1.9.2
@@ -151,7 +151,7 @@ purepy_packages:
         insert_setuptools: true
     WebError:
         version: 0.10.3
-        pinned: true
+        version_specifier: <0.11
     WebHelpers:
         version: 1.3
     WebOb:


### PR DESCRIPTION
Add the wheel_updates command to list wheels with newer versions on PyPI. Introduce the `pinned` attribute on packages in wheels.yml to exclude them from this check.

~~TODO: just realized rather than a "yes/no" pinned state, we may need to support standard pkg_resources version specifiers, e.g. we should get additional patches to mercurial 3.4 but not upgrade to >= 3.5. So mercurial should be "pinned" to <= 3.5~~
