### PR TITLE
Prepare for ripping pulsar out of Galaxy.

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -16,6 +16,8 @@ packages:
         insert_setuptools: true
     numpy:
         version: 1.9.2
+    psutil:
+        version: 4.0.0
     psycopg2:
         version: 2.6.1
         src:
@@ -125,8 +127,6 @@ purepy_packages:
         src:
             - https://github.com/natefoo/pip/archive/03c981a2d4659d3087397dc9fd6500437998be5c.tar.gz
         prebuild: sed -i -e 's/__version__ = "8\.0\.2"/__version__ = "8.0.2+gx2"/' ${SRC_ROOT}/pip/__init__.py
-    psutil:
-        version: 4.0.0
     pulsar-galaxy-lib:
         version: 0.7.0.dev1
         prebuild: sed -i -e 's/DEFAULT_PULSAR_GALAXY_LIB = 0/DEFAULT_PULSAR_GALAXY_LIB = 1/' ${SRC_ROOT}/setup.py

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -125,6 +125,10 @@ purepy_packages:
         src:
             - https://github.com/natefoo/pip/archive/03c981a2d4659d3087397dc9fd6500437998be5c.tar.gz
         prebuild: sed -i -e 's/__version__ = "8\.0\.2"/__version__ = "8.0.2+gx2"/' ${SRC_ROOT}/pip/__init__.py
+    psutil:
+        version: 4.0.0
+    pulsar-galaxy-lib:
+        version: 0.7.0.dev0
     Pygments:
         version: 2.0.2
     pytz:

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -17,7 +17,7 @@ packages:
     numpy:
         version: 1.9.2
     psutil:
-        version: 4.0.0
+        version: 4.1.0
     psycopg2:
         version: 2.6.1
         src:

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -128,7 +128,8 @@ purepy_packages:
     psutil:
         version: 4.0.0
     pulsar-galaxy-lib:
-        version: 0.7.0.dev0
+        version: 0.7.0.dev1
+        prebuild: sed -i -e 's/DEFAULT_PULSAR_GALAXY_LIB = 0/DEFAULT_PULSAR_GALAXY_LIB = 1/' ${SRC_ROOT}/setup.py
     Pygments:
         version: 2.0.2
     pytz:


### PR DESCRIPTION
pulsar-galaxy-lib is a new PyPI dependency that is Pulsar without galaxy-lib - it is meant to stand for pulsar as library for galaxy not a pulsar version of galaxy-lib. 
