### PR TITLE
Fix build recipe for R.

### DIFF
--- a/R/build.sh
+++ b/R/build.sh
@@ -47,9 +47,10 @@ apt-get -qq update &&
     sed -i 's#/build/dest#${R_ROOT_DIR}#g' /build/dest/bin/R &&
     sed -i 's#/build/dest#${R_ROOT_DIR}#g' /build/dest/lib/R/bin/R &&
     sed -i 's#/build/dest#$(R_ROOT_DIR)#g' /build/dest/lib/R/etc/Makeconf &&
+    sed -i 's#^LDFLAGS = #LDFLAGS = -L$(R_ROOT_DIR)/lib #' /build/dest/lib/R/etc/Makeconf &&
     cp /usr/lib/libgfortran* /build/dest/lib/ &&
     cp /usr/lib/libgomp* /build/dest/lib/ &&
-    cp /usr/lib/libblas.so.3gf /build/dest/lib &&
+    cp /usr/lib/libblas* /build/dest/lib/ &&
     cd /build/dest/lib &&
     ln -s libgfortran.so.3 libgfortran.so &&
     ln -s libgomp.so.1.0.0 libgomp.so &&

--- a/image/Dockerfile.in
+++ b/image/Dockerfile.in
@@ -6,7 +6,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 VOLUME ["/host"]
 
-RUN apt-get -qq update && \
+RUN sed -i 's#deb http://httpredir.debian.org/debian squeeze main#deb http://archive.debian.org/debian squeeze main#g' /etc/apt/sources.list && \
+    apt-get -qq update && \
     apt-get install --no-install-recommends -y wget build-essential ADDITIONAL_BUILD_PACKAGES
 
 ENTRYPOINT ["/bin/bash", "/host/build.sh"]


### PR DESCRIPTION
- Update Dockerfile.in to reflect changes in where squeeze's repositories are located.
- Copy libblas.so as well as libblas.so.3gf to /build/dest/lib.
- Add `-L$R_ROOT_DIR/lib` to the Makeconf's LDFLAGS so R packages that depend on it can find libblas.so at build time.
