### PR TITLE
Update six to 1.10.0.

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -185,7 +185,7 @@ purepy_packages:
     selenium:
         version: 3.0.1
     six:
-        version: 1.9.0
+        version: 1.10.0
     sqlalchemy-migrate:
         version: 0.10.0
     sqlparse:


### PR DESCRIPTION
A new setuptools was released which depends on this and it is breaking Travis CI that we are installing an old one.

https://travis-ci.org/galaxyproject/galaxy/jobs/194699159.