### PR TITLE
Add wheel for ipaddress.

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -140,6 +140,8 @@ purepy_packages:
         version: 1.10.2
     galaxy_sequence_utils:
         version: 1.0.2
+    ipaddress:
+        version: 1.0.18
     jstree:
         version: 0.4
     kamaki:


### PR DESCRIPTION
Module will let Galaxy reason about ipaddresses - a good non-hacky way to verifying the upload tool for instance isn't trying to fetch content from an intranet ip address unless said IP appears in some sort of include list.

Ping @erasche.