### PR TITLE
Update `requests` package version.

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -190,7 +190,7 @@ purepy_packages:
     repoze.lru:
         version: 0.6
     requests:
-        version: 2.8.1
+        version: 2.10.0
     requests-toolbelt:
         version: 0.4.0
     Routes:


### PR DESCRIPTION
Update `requests` package version from `2.8.1` to `2.10.0` which is a minimum required version for `cloudbridge` wheel. 