### PR TITLE
Update CloudBridge to its current latest version

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -124,7 +124,7 @@ purepy_packages:
     chronos-python:
         version: 0.38.0
     cloudbridge:
-        version: 0.3.2
+        version: 0.3.3
     decorator:
         version: 4.0.2
     dictobj:


### PR DESCRIPTION
Another update to the `CloudBridge`. 
The newest version is available at the following link: 
https://pypi.org/project/cloudbridge/