### PR TITLE
Update wheels.yml

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -157,6 +157,8 @@ purepy_packages:
         version: 1.3.7
     numpy-stl:
         version: 1.9.1
+    oauth2client:
+        version: 4.1.2
     paramiko:
         version: 2.2.1
     Parsley:


### PR DESCRIPTION
Add Google OAuth2.0 API wheel. This wheel is used for authentication/authorization agains Google, which is being developed in [this](https://github.com/VJalili/galaxy/tree/oauth2) branch.