### PR TITLE
Update wheels, add httplib2

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -140,6 +140,8 @@ purepy_packages:
         version: 1.13.2
     galaxy_sequence_utils:
         version: 1.0.2
+    httplib2:
+        version: 0.10.3
     ipaddress:
         version: 1.0.18
     jstree:


### PR DESCRIPTION
This library is used in Google `OAuth2.0` API, which is under development at [this](https://github.com/VJalili/galaxy/tree/oauth2) branch. 