### PR TITLE
Update sqlalchemy and pbr

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -171,7 +171,7 @@ purepy_packages:
     PasteDeploy:
         version: 1.5.2
     pbr:
-        version: 1.8.0
+        version: 2.0.0
     pip:
         version: 8.0.2+gx2
         src:
@@ -204,7 +204,7 @@ purepy_packages:
     six:
         version: 1.10.0
     sqlalchemy-migrate:
-        version: 0.10.0
+        version: 0.11.0
     sqlparse:
         version: 0.1.16
     starforge:


### PR DESCRIPTION
`pbr>=2.0.0` is an indirect requirement of [CloudBridge](https://github.com/gvlproject/cloudbridge); hence it is required for some of CloudBridge functionalities. 

`pbr==1.8.0` is also a [pinned requirement](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/pinned-requirements.txt#L65) for sqlalchemy-migrate. However, it seems the sqlalchemy-migrate v.11.0 works with newer versions of `pbr` (see [this message](https://github.com/openstack/sqlalchemy-migrate/commit/ca6f3a93b5264f4b92d195066681a81bebcfa88b)). So, I'm not expecting a break in Galaxy database migration with newer version of sqlalchemy-migrate. 

Therefore, I guess we could upgrade to `pbr v2.0.0` and sqlalchemy-migrate `v.11.0` without breaking anything.