### PR TITLE
Attempt to build standard pysam 0.12

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -49,9 +49,14 @@ packages:
     pysam:
         version: 0.12
         prebuild:
+            #wheel: sed -i '/\[bdist_wheel\]/a extra_compile_args = -D_GNU_SOURCE' ${SRC_ROOT}/setup.cfg && cat ${SRC_ROOT}/setup.cfg && for py in /python/cp*-`uname -m`; do ${py}/bin/easy_install 'cython' || exit 1; done
             wheel: for py in /python/cp*-`uname -m`; do ${py}/bin/easy_install 'cython' || exit 1; done
         yum:
+            - bzip2-devel
             - zlib-devel
+            - xz-devel
+            - curl-devel
+        build_args: build_ext -D_GNU_SOURCE --disable-libcurl
     pysqlite:
         # pysqlite is dropped because SQLAlchemy will just use sqlite3 from
         # Python's stdlib, but keeping the rule here in case we have to add it

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -55,7 +55,6 @@ packages:
             - bzip2-devel
             - zlib-devel
             - xz-devel
-        build_args: build_ext -D_GNU_SOURCE
     pysqlite:
         # pysqlite is dropped because SQLAlchemy will just use sqlite3 from
         # Python's stdlib, but keeping the rule here in case we have to add it

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -55,6 +55,8 @@ packages:
             - bzip2-devel
             - zlib-devel
             - xz-devel
+        brew:
+            - xz
     pysqlite:
         # pysqlite is dropped because SQLAlchemy will just use sqlite3 from
         # Python's stdlib, but keeping the rule here in case we have to add it

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -55,8 +55,7 @@ packages:
             - bzip2-devel
             - zlib-devel
             - xz-devel
-            - curl-devel
-        build_args: build_ext -D_GNU_SOURCE --disable-libcurl
+        build_args: build_ext -D_GNU_SOURCE
     pysqlite:
         # pysqlite is dropped because SQLAlchemy will just use sqlite3 from
         # Python's stdlib, but keeping the rule here in case we have to add it

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -48,6 +48,8 @@ packages:
         insert_setuptools: true
     pysam:
         version: 0.12
+        prebuild:
+            wheel: for py in /python/cp*-`uname -m`; do ${py}/bin/easy_install 'cython' || exit 1; done
         yum:
             - zlib-devel
     pysqlite:

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -47,13 +47,7 @@ packages:
         version: 2.6.1
         insert_setuptools: true
     pysam:
-        version: 0.8.4+gx5
-        src:
-            - https://github.com/dannon/pysam/archive/v0.8.4_gx5.tar.gz
-        # https://github.com/pysam-developers/pysam/issues/164
-        prebuild:
-            wheel: for py in /python/cp*-`uname -m`; do ${py}/bin/easy_install 'cython<0.23' || exit 1; done
-            all: sed -i -e 's/0\.8\.4/0.8.4+gx5/' ${SRC_ROOT}/pysam/version.py
+        version: 0.12
         yum:
             - zlib-devel
     pysqlite:


### PR DESCRIPTION
Pointed out by @mvdbeek, it may be possible to switch away from our custom fork now due to improvements in newer versions of htslib and pysam.