### PR TITLE
Fix bug whereby the wrong directory was used as the cwd when building wheels with more than once source

### DIFF
--- a/starforge/__init__.py
+++ b/starforge/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 
 PROJECT_NAME = "starforge"

--- a/starforge/forge/wheels.py
+++ b/starforge/forge/wheels.py
@@ -133,8 +133,7 @@ class ForgeWheel(object):
             arc = Archive.open(arc_path)
             assert len(arc.roots) == 1, \
                 "Could not determine root directory in archive"
-            root = next(iter(arc.roots))
-            root_t = abspath(join(getcwd(), root))
+            root_t = abspath(join(getcwd(), next(iter(arc.roots))))
             os.environ['SRC_ROOT_%d' % i] = root_t
             # will cd to first root
             if i == 0:


### PR DESCRIPTION
Thanks @abretaud!

Bump version to 0.3.2.

Fixes #153.