### PR TITLE
Use delocate on macOS wheel builds

### DIFF
--- a/starforge/config/default.yml
+++ b/starforge/config/default.yml
@@ -16,6 +16,11 @@ imagesets:
         - starforge/manylinux1:latest
         - starforge/manylinux1-32:latest
         - starforge/osx-wheel:10.6
+    linux-wheel:
+        - starforge/manylinux1:latest
+        - starforge/manylinux1-32:latest
+    macos-wheel:
+        - starforge/osx-wheel:10.6
     full-wheel:
         - starforge/debian-wheel:7
         - starforge/debian-wheel:8
@@ -123,6 +128,7 @@ images:
         pythons:
             - /python/cp27m-{arch}/bin/python
         plat_name: macosx_10_6_intel
+        postbuild: for whl in dist/*.whl; do /python/wheelenv/bin/delocate-wheel -v $whl; done
         run_cmd: >
             qemu-system-x86_64
             -enable-kvm

--- a/wheels/image/osx-playbook.yml
+++ b/wheels/image/osx-playbook.yml
@@ -6,10 +6,9 @@
     work_dir: /build
     py27_version: 2.7.13
     py27_sha256: 0843c59d394c64f24a5f9c342c7f41f8ae4e3adc65e32f24cc6f4a07cf55741a
-    virtualenv_version: 13.1.2
-    virtualenv_sha256: aabc8ef18cddbd8a2a9c7f92bc43e2fea54b1147330d65db920ef3ce9812e3dc
-    setuptools_version: 18.3.2
-    setuptools_sha256: 8c4ab0c4f227730519dc1e020f875b3ef97e643c8f43a98a4fa0c46fbad12450
+    virtualenv_version: 15.1.0
+    virtualenv_url: https://pypi.python.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz
+    virtualenv_sha256: 02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a
     user_public_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCruS3Vk9D5u0lHSEwjO5g0WefvGzP/F0O9LhywRepFUxeZ9WKNiay+S/xi0y/1neJV+zEmy0/6SLGpT5L20ZgzpVMR5iFnJV+q0JENrhJ4uq/pedVkWCW1nA9HgAVqyBn94WXwuZGEovIK+XmeNXMdlPO7jerjUTLGCiefiCnCQqseJqjjEpqTRpAkl5YEZulZzfoBryzaHlzudryhkiRlJbmzuvhd75exbM25YHgs9lT+s+tRrS0UqEejNkz9P+W3HD4ICzc2zlu6O1mtdaReUlkass11ECYCOwMJTmRE1cy+j0SAbhhQLlLIgLbP/8DEiOi2vymdoH96R8BU9TKx user@mjolnir0
   tasks:
 
@@ -80,7 +79,7 @@
 
   - name: Fetch virtualenv
     get_url:
-      url: https://pypi.python.org/packages/source/v/virtualenv/virtualenv-{{ virtualenv_version }}.tar.gz
+      url: "{{ virtualenv_url }}"
       sha256sum: "{{ virtualenv_sha256 }}"
       dest: "{{ work_dir }}/virtualenv-{{ virtualenv_version }}.tar.gz"
 
@@ -93,9 +92,14 @@
 
   - name: Create wheelenv
     pip:
-      name: pip
+      name: "{{ item }}"
+      state: latest
       virtualenv: /python/wheelenv
       virtualenv_command: /usr/bin/python {{ work_dir }}/virtualenv-{{ virtualenv_version }}/virtualenv.py
+    with_items:
+      - pip
+      - setuptools
+      - delocate
 
   - name: Fetch get-pip
     get_url:


### PR DESCRIPTION
Doesn't actually require a version bump since I just rebuilt the macOS image for Jenkins off this commit and the changes are basically to the playbook and config, which has to be installed by hand. =(