### PR TITLE
Don't build sdists with the `wheel` subcommand by default, bump to 0.3.3.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ Starforge is maintained by the `Galaxy`_ Project and community. A `list of
 contributors <https://github.com/galaxyproject/starforge/graphs/contributors>`_
 to the project can be found on GitHub.
 
+0.3.3 (2017-09-08)
+~~~~~~~~~~~~~~~~~~
+
+- Do not build sdists with the `wheel` subcommand by default. (#155)
+
 0.3.2 (2017-09-08)
 ~~~~~~~~~~~~~~~~~~
 

--- a/starforge/__init__.py
+++ b/starforge/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 
 PROJECT_NAME = "starforge"

--- a/starforge/commands/cmd_wheel.py
+++ b/starforge/commands/cmd_wheel.py
@@ -45,6 +45,9 @@ GUEST_SHARE = '/share'
                               resolve_path=False),
               help='Path file containing OSK, if the guest requires it '
                    '(default: %s)' % xdg_config_file(name='osk.txt'))
+@click.option('--sdist/--no-sdist',
+              default=False,
+              help='Build source distribution')
 @click.option('--docker/--no-docker',
               default=True,
               help='Build under Docker')
@@ -61,7 +64,7 @@ GUEST_SHARE = '/share'
                    'even if a previous image fails)')
 @click.argument('wheel')
 @pass_context
-def cli(ctx, wheels_config, osk, docker, qemu, wheel, qemu_port,
+def cli(ctx, wheels_config, osk, sdist, docker, qemu, wheel, qemu_port,
         exit_on_failure):
     """ Build a wheel.
     """
@@ -103,6 +106,9 @@ def cli(ctx, wheels_config, osk, docker, qemu, wheel, qemu_port,
                 fatal("Exiting due to missing wheels")
         else:
             info('All wheels from image %s already built', image_name)
+
+    if not sdist:
+        return
 
     image = filter(lambda x: x.type == 'docker',
                    itervalues(wheel_config.images))[0]

--- a/wheels/build/jenkins.sh
+++ b/wheels/build/jenkins.sh
@@ -27,7 +27,7 @@ function build_wheel()
     outtmp=$(ssh ${sfuser}@${sfbuild} mktemp -d)
     ssh ${sfuser}@${sfbuild} "cd $outtmp && PATH="/sbin:\$PATH" && . ${sfvenv}/bin/activate && starforge --debug wheel --wheels-config=$l_new --exit-on-failure $l_wheel"
     [ ! -d ${output} ] && mkdir -p ${output}
-    scp ${sfuser}@${sfbuild}:${outtmp}/\*.whl ${sfuser}@${sfbuild}:${outtmp}/\*.tar.gz ${output}
+    scp ${sfuser}@${sfbuild}:${outtmp}/\*.whl ${output}
     echo "Contents of ${output} after building ${l_wheel}:"
     ls -l ${output}
 }
@@ -58,7 +58,7 @@ if [ -z "$1" -o "$1" = 'none' ]; then
             esac
         done < <(ssh ${sfuser}@${sfbuild} ${sfvenv}/bin/starforge wheel_diff --wheels-config=$new $old)
         for wheel in "${build_wheels[@]}"; do
-            echo "Building '$wheel' wheel and sdist"
+            echo "Building '$wheel' wheel"
             build_wheel $wheel $new
         done
         ssh ${sfuser}@${sfbuild} "rm ${new} ${old}"


### PR DESCRIPTION
This is workaround, but not a fix, for #157.