### PR TITLE
Support xz/lzma tarballs for wheel builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires = requirements,
     extras_require = {
         ':python_version=="2.6"': ["ordereddict"],
+        'lzma:python_version<="3.3"': ['backports.lzma'],
         'platform_specific': ["lionshead"],
     },
     entry_points = {

--- a/wheels/image/manylinux1-32/Dockerfile
+++ b/wheels/image/manylinux1-32/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Nate Coraor <nate@bx.psu.edu>
 
 VOLUME ["/host"]
 
-RUN /usr/bin/linux32 yum install -y PyYAML
+RUN /usr/bin/linux32 yum install -y PyYAML xz-devel
 
 WORKDIR /work
 
@@ -17,7 +17,7 @@ RUN /opt/wheelenv/bin/pip install --upgrade pip setuptools
 WORKDIR /
 
 COPY starforge.tar.gz /work/starforge.tar.gz
-RUN /usr/bin/linux32 /opt/wheelenv/bin/pip install /work/starforge.tar.gz
+RUN /usr/bin/linux32 /opt/wheelenv/bin/pip install /work/starforge.tar.gz[lzma]
 
 RUN rm -rf /work /root/.cache && \
     yum clean all

--- a/wheels/image/manylinux1/Dockerfile
+++ b/wheels/image/manylinux1/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Nate Coraor <nate@bx.psu.edu>
 
 VOLUME ["/host"]
 
-RUN yum install -y PyYAML
+RUN yum install -y PyYAML xz-devel
 
 WORKDIR /work
 
@@ -17,7 +17,7 @@ RUN /opt/wheelenv/bin/pip install --upgrade pip setuptools
 WORKDIR /
 
 COPY starforge.tar.gz /work/starforge.tar.gz
-RUN /opt/wheelenv/bin/pip install /work/starforge.tar.gz
+RUN /opt/wheelenv/bin/pip install /work/starforge.tar.gz[lzma]
 
 RUN rm -rf /work /root/.cache && \
     yum clean all

--- a/wheels/image/osx-playbook.yml
+++ b/wheels/image/osx-playbook.yml
@@ -125,7 +125,7 @@
       - 2.7
 
   - name: Install Starforge
-    command: /python/{{ item }}/bin/pip install {{ work_dir }}/starforge.tar.gz
+    command: /python/{{ item }}/bin/pip install {{ work_dir }}/starforge.tar.gz[lzma]
     args:
       creates: /python/{{ item }}/bin/starforge
     with_items:

--- a/wheels/image/osx-playbook.yml
+++ b/wheels/image/osx-playbook.yml
@@ -124,14 +124,6 @@
     with_items:
       - 2.7
 
-  - name: Install Starforge
-    command: /python/{{ item }}/bin/pip install {{ work_dir }}/starforge.tar.gz[lzma]
-    args:
-      creates: /python/{{ item }}/bin/starforge
-    with_items:
-      - wheelenv
-      - cp27m-x86_64
-
   - name: Allow admin(s) to sudo without a password
     lineinfile:
       dest: /etc/sudoers
@@ -143,3 +135,16 @@
     shell: ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" </dev/null
     args:
       creates: /usr/local/bin/brew
+
+  - name: Install xz
+    remote_user: admin
+    homebrew:
+      name: xz
+
+  - name: Install Starforge
+    command: /python/{{ item }}/bin/pip install {{ work_dir }}/starforge.tar.gz[lzma]
+    args:
+      creates: /python/{{ item }}/bin/starforge
+    with_items:
+      - wheelenv
+      - cp27m-x86_64


### PR DESCRIPTION
The dependent library will only be installed if you install with the `[lzma]` feature since `backports.lzma` requires that the xz/lzma development libraries be installed (and they aren't by default on most systems).

Should make #146 buildable once this is released and Jenkins is updated.