### PR TITLE
uWSGI wheel: Apply patch to work around pyuwsgi bug on macOS

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -146,7 +146,7 @@ packages:
         prebuild:
             all: cp ${SRC_ROOT_0}/setup.cpyext.py ${SRC_ROOT_0}/setup.py
             wheel: >
-              [ `uname -s` = 'Darwin' ] &&
+              [ `uname -s` != 'Darwin' ] ||
               curl https://github.com/natefoo/uwsgi/commit/2a85be614afac37a467712d048f1d9eef6e7d622.patch |
               patch -d ${SRC_ROOT_0} -p1
 purepy_packages:

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -143,8 +143,12 @@ packages:
         version: 1.0.15
     uWSGI:
         version: 2.0.15
-        prebuild: cp ${SRC_ROOT_0}/setup.cpyext.py ${SRC_ROOT_0}/setup.py
-
+        prebuild:
+            all: cp ${SRC_ROOT_0}/setup.cpyext.py ${SRC_ROOT_0}/setup.py
+            wheel: >
+              [ `uname -s` = 'Darwin' ] &&
+              curl https://github.com/natefoo/uwsgi/commit/2a85be614afac37a467712d048f1d9eef6e7d622.patch |
+              patch -d ${SRC_ROOT_0} -p1
 purepy_packages:
     amqp:
         version: 1.4.8


### PR DESCRIPTION
See unbit/uwsgi#1680

I don't want to update the version to some kind of custom tag like `2.0.15+gx1`, because that moves us further from `pip install -r requirements.txt` without needing wheels.galaxyproject.org. This issue only affected macOS, only (at least for @dannon and me) when logging in over ssh. The existing 2.0.15 Linux wheels are fine, and uWSGI 2.0.15 was mot included in Galaxy's requirements.txt until 17.09.

I propose that I just replace the existing macOS wheel for 2.0.15 on wheels.galaxyproject.org with this fixed one. macOS users on 17.09 or later who've already downloaded the broken wheel and who encounter this problem can simply reinstall with:

```sh-session
(.venv)$ pip install --index-url https://wheels.galaxyproject.org/simple/ --upgrade uWSGI==2.0.15
```

Or just drop `--index-url https://wheels.galaxyproject.org/simple/` to compile and install from the source tarball from PyPI.