### PR TITLE
Install PCRE when building uWSGI to enable internal routing support

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -149,6 +149,12 @@ packages:
               [ `uname -s` != 'Darwin' ] ||
               curl https://github.com/natefoo/uwsgi/commit/2a85be614afac37a467712d048f1d9eef6e7d622.patch |
               patch -d ${SRC_ROOT_0} -p1
+        apt:
+            - libpcre2-dev
+        yum:
+            - pcre-devel
+        brew:
+            - pcre
 purepy_packages:
     amqp:
         version: 1.4.8


### PR DESCRIPTION
Needed for out-of-the-box GIE proxying.