### PR TITLE
rev sqlalchemy to 1.2.2

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -140,7 +140,7 @@ packages:
         yum:
             - libyaml-devel
     SQLAlchemy:
-        version: 1.0.15
+        version: 1.2.2
     uWSGI:
         version: 2.0.15
         prebuild:


### PR DESCRIPTION
I'd like to be able to use selectinloads when optimizing Galaxy - http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#sqlalchemy.orm.selectinload.