### PR TITLE
Regenerate docopt wheel [1/2]

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -185,8 +185,6 @@ purepy_packages:
         version: 4.0.2
     dictobj:
         version: 0.3.1
-    docopt:
-        version: 0.6.2
     docutils:
         version: 0.12
         insert_setuptools: true


### PR DESCRIPTION
By removing and re-adding it from `wheels/build/wheels.yml` .