### PR TITLE
Adds isa-rwval, a minimal isa-tools setup.

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -206,8 +206,6 @@ purepy_packages:
         version: 1.0.18
     isa.rwval:
         version: 0.10.0
-        src:
-            - https://github.com/ISA-tools/isa-rwval/archive/449d118aea26df2ac3f1ea40481859a4a8c6b20c.tar.gz
     jstree:
         version: 0.4
     kamaki:

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -204,7 +204,7 @@ purepy_packages:
         version: 2.6
     ipaddress:
         version: 1.0.18
-    isa.rwval:
+    isa-rwval:
         version: 0.10.0
     jstree:
         version: 0.4

--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -204,6 +204,10 @@ purepy_packages:
         version: 2.6
     ipaddress:
         version: 1.0.18
+    isa.rwval:
+        version: 0.10.0
+        src:
+            - https://github.com/ISA-tools/isa-rwval/archive/449d118aea26df2ac3f1ea40481859a4a8c6b20c.tar.gz
     jstree:
         version: 0.4
     kamaki:


### PR DESCRIPTION
This is for the upcoming ISA Composite Datatype to be PRed to the main Galaxy project soon. This is a minimal ISA-Tools installation with stripped functionality to avoid heavy dependencies, but with everything needed for the composite datatype.

`isa.rwval-0.10.0-py2-none-any.whl` built without issues

Thanks!
Pablo