### PR TITLE
Update uWSGI to 2.0.17 and stop building as pyuwsgi

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -141,13 +141,7 @@ packages:
     SQLAlchemy:
         version: 1.2.2
     uWSGI:
-        version: 2.0.15
-        prebuild:
-            all: cp ${SRC_ROOT_0}/setup.cpyext.py ${SRC_ROOT_0}/setup.py
-            wheel: >
-              [ `uname -s` != 'Darwin' ] ||
-              curl https://github.com/natefoo/uwsgi/commit/2a85be614afac37a467712d048f1d9eef6e7d622.patch |
-              patch -d ${SRC_ROOT_0} -p1
+        version: 2.0.17
     watchdog:
         version: 0.8.3
         imageset: macos-wheel


### PR DESCRIPTION
Because apparently it's not actually necessary to build as pyuwsgi? And I can't recall why we did in the first place.