### PR TITLE
 Add ``--output`` option to ``wheel_info``

### DIFF
--- a/starforge/cache.py
+++ b/starforge/cache.py
@@ -19,7 +19,11 @@ from pkg_resources import parse_version
 from six import with_metaclass
 
 from .io import warn, info, debug, fatal
-from .util import pip_install, py_to_pip
+from .util import (
+    pip_install,
+    py_to_pip,
+    stringify_cmd
+)
 
 
 class BaseCacher(with_metaclass(ABCMeta, object)):
@@ -174,7 +178,7 @@ class PipSourceCacher(TarballCacher):
                     '--no-deps', name + '==' + version
                 ]
                 info('Fetching sdist: %s', name)
-                debug('Executing: %s', ' '.join(cmd))
+                debug('Executing: %s', stringify_cmd(cmd))
                 subprocess.check_call(cmd, stdout=sys.stderr)
                 cfpath = self.check(name, version=version)
             except subprocess.CalledProcessError:
@@ -230,7 +234,7 @@ def cache_wheel_sources(cache_manager, wheel_config):
     if wheel_config.setup_requires:
         # this is done due to pypa/pip#1884 - `pip download` fails under certain circumstances if setup_requires is set
         info("Installing packages to Starforge Python at '%s' for '%s' setup requirements: %s",
-            sys.executable, wheel_config.name, ', '.join(wheel_config.setup_requires))
+             sys.executable, wheel_config.name, ', '.join(wheel_config.setup_requires))
         pip_install(pip=py_to_pip(sys.executable), packages=wheel_config.setup_requires)
     sources.append(cache_manager.pip_cache(wheel_config.name, wheel_config.version, fail_ok=fail_ok))
     for src_url in wheel_config.sources:

--- a/starforge/commands/cmd_wheel.py
+++ b/starforge/commands/cmd_wheel.py
@@ -10,7 +10,7 @@ from shutil import copy
 import click
 import yaml
 
-from ..io import debug, error, info, warn, fatal
+from ..io import error, info, warn, fatal
 from ..cli import pass_context
 from ..forge.wheels import build_forges
 from ..cache import cache_wheel_sources, check_wheel_source
@@ -142,7 +142,6 @@ def _prep_build(debug, global_config, wheels_config, template, image, wheel_name
     if isabs(image.buildpy):
         cmd = join(dirname(image.buildpy), cmd)
     share = [(abspath(getcwd()), GUEST_HOST, 'rw'),
-             (abspath(xdg_cache_dir()), join(GUEST_SHARE,
-                                            'galaxy-starforge'), 'ro')]
+             (abspath(xdg_cache_dir()), join(GUEST_SHARE, 'galaxy-starforge'), 'ro')]
     env = {'XDG_CACHE_HOME': GUEST_SHARE}
     return (cmd, share, env)

--- a/starforge/commands/cmd_wheel_type.py
+++ b/starforge/commands/cmd_wheel_type.py
@@ -14,8 +14,9 @@ import click
 from ..cache import CacheManager, cache_wheel_sources
 from ..cli import pass_context
 from ..config.wheels import WheelConfigManager
-from ..io import debug, fatal, info
-from ..util import PythonSdist, xdg_config_file
+from ..io import fatal, info
+from ..packaging.setup import PythonSdist
+from ..util import xdg_config_file
 
 
 # FIXME: dedup

--- a/starforge/commands/cmd_wheel_type.py
+++ b/starforge/commands/cmd_wheel_type.py
@@ -2,13 +2,6 @@
 """
 from __future__ import absolute_import
 
-from os.path import join
-
-try:
-    from tempfile import TemporaryDirectory
-except ImportError:
-    from backports.tempfile import TemporaryDirectory
-
 import click
 
 from ..cache import CacheManager, cache_wheel_sources

--- a/starforge/config/wheels.py
+++ b/starforge/config/wheels.py
@@ -66,7 +66,6 @@ class WheelConfig(object):
             self.configured_wheel_type = C_EXTENSION
         self.set_imageset()
 
-
     def detect_imageset(self, cache_manager):
         debug("Configured wheel imageset: %s", self.configured_imageset)
         wheel_type = self.configured_wheel_type
@@ -92,7 +91,6 @@ class WheelConfig(object):
         else:
             self.set_purepy(False)
             # sets universal
-
 
     def set_imageset(self, imageset=None, force=False):
         if self.configured_imageset is not None and not force:

--- a/starforge/config/wheels.py
+++ b/starforge/config/wheels.py
@@ -13,7 +13,7 @@ from six import iteritems, string_types
 
 from ..cache import cache_wheel_sources
 from ..io import debug, info, fatal
-from ..util import PythonSdist
+from ..packaging.setup import PythonSdist
 
 
 DEFAULT_IMAGESET = 'default-wheel'

--- a/starforge/execution/__init__.py
+++ b/starforge/execution/__init__.py
@@ -5,12 +5,11 @@ from __future__ import absolute_import
 import shlex
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
 
-from six import with_metaclass, string_types
+from six import (
+    string_types,
+    with_metaclass
+)
 
 
 class ExecutionContext(with_metaclass(ABCMeta, object)):
@@ -21,14 +20,6 @@ class ExecutionContext(with_metaclass(ABCMeta, object)):
         if isinstance(cmd, string_types):
             cmd = shlex.split(cmd)
         return cmd
-
-    def stringify_cmd(self, cmd):
-        if isinstance(cmd, string_types):
-            return cmd
-        r = ''
-        for e in cmd:
-            r += quote(e) + ' '
-        return r.strip()
 
     @contextmanager
     def run_context(self, **kwargs):

--- a/starforge/execution/docker.py
+++ b/starforge/execution/docker.py
@@ -3,16 +3,16 @@
 from __future__ import absolute_import
 
 from os import unlink
-from subprocess import check_call
-try:
-    from subprocess import check_output
-except ImportError:
-    from ..util import check_output
+from subprocess import (
+    check_call,
+    check_output
+)
 
 from six import iteritems
 
-from ..io import info
 from . import ExecutionContext
+from ..io import info
+from ..util import stringify_cmd
 
 
 class DockerExecutionContext(ExecutionContext):
@@ -50,7 +50,7 @@ class DockerExecutionContext(ExecutionContext):
         run_cmd.extend(cmd)
         if self.use_sudo:
             run_cmd = ['sudo'] + run_cmd
-        info('Running docker: %s', ' '.join(run_cmd))
+        info('Running docker: %s', stringify_cmd(run_cmd))
         output = None
         if capture_output:
             output = check_output(run_cmd)

--- a/starforge/execution/local.py
+++ b/starforge/execution/local.py
@@ -2,14 +2,14 @@
 """
 from __future__ import absolute_import
 
-from subprocess import check_call
-try:
-    from subprocess import check_output
-except ImportError:
-    from ..util import check_output
+from subprocess import (
+    check_call,
+    check_output
+)
 
-from ..io import info
 from . import ExecutionContext
+from ..io import info
+from ..util import stringify_cmd
 
 
 class LocalExecutionContext(ExecutionContext):
@@ -21,7 +21,7 @@ class LocalExecutionContext(ExecutionContext):
 
     def run(self, cmd, cwd=None, capture_output=False, **kwargs):
         cmd = self.normalize_cmd(cmd)
-        info('Running local: %s', ' '.join(cmd))
+        info('Running local: %s', stringify_cmd(cmd))
         if capture_output:
             return check_output(cmd, cwd=cwd)
         else:

--- a/starforge/execution/qemu.py
+++ b/starforge/execution/qemu.py
@@ -18,8 +18,13 @@ from time import sleep
 
 from six import iteritems, b
 
-from ..io import warn, info, error
 from . import ExecutionContext
+from ..io import (
+    info,
+    error,
+    warn
+)
+from ..util import stringify_cmd
 
 
 SSH_EXEC_TEMPLATE = '''from subprocess import Popen
@@ -147,11 +152,11 @@ class QEMUExecutionContext(ExecutionContext):
                           '--', self.image.buildpy, guest_temp])
             if cmd:
                 info('%s %s executes: %s',
-                     self.image.buildpy, guest_temp, self.stringify_cmd(cmd))
+                     self.image.buildpy, guest_temp, stringify_cmd(cmd))
             else:
                 info('%s %s executes with args: %s',
                      self.image.buildpy, guest_temp, str(args))
-        info('Executing: %s', self.stringify_cmd(ssh_cmd))
+        info('Executing: %s', stringify_cmd(ssh_cmd))
         try:
             if capture_output:
                 return check_output(ssh_cmd)
@@ -172,7 +177,7 @@ class QEMUExecutionContext(ExecutionContext):
     def _scp(self, cmd):
         cmd = self.normalize_cmd(cmd)
         cmd = ['scp'] + self.ssh_args + cmd
-        info('Executing: %s', self.stringify_cmd(cmd))
+        info('Executing: %s', stringify_cmd(cmd))
         check_call(cmd)
 
     def start(self, share=None, env=None, **kwargs):
@@ -244,7 +249,7 @@ class QEMUExecutionContext(ExecutionContext):
             run_cmd.append('-device')
             run_cmd.append('isa-applesmc,osk={osk}'.format(osk=self.osk))
             display_cmd.extend(['-device', 'isa-applesmc,osk=redacted'])
-        info('Running qemu-system: %s', self.stringify_cmd(display_cmd))
+        info('Running qemu-system: %s', stringify_cmd(display_cmd))
 
         # snapshot the source image for this run
         cmd = ('btrfs subvolume snapshot {src} {dest}'

--- a/starforge/forge/wheels.py
+++ b/starforge/forge/wheels.py
@@ -12,12 +12,10 @@ from os import (
     getcwd,
     listdir,
     makedirs,
-    rename,
     uname
 )
 from os.path import (
     abspath,
-    dirname,
     exists,
     join
 )
@@ -240,7 +238,7 @@ class ForgeWheel(object):
         # install setup requirements (these can be defined by the setup script but that presents a catch-22, so only
         # check the wheel config
         self._build_py_pip_install([self.image.buildpy], self.wheel_config.setup_requires,
-            dependency_type='Starforge image Python setup_requires')
+                                   dependency_type='Starforge image Python setup_requires')
         self._build_py_pip_install(pythons, self.wheel_config.setup_requires, dependency_type='setup_requires')
 
         insert_setuptools = self.wheel_config.insert_setuptools

--- a/starforge/io.py
+++ b/starforge/io.py
@@ -12,9 +12,9 @@ DEBUG = False
 
 
 def debug(message, *args):
-    if args:
-        message = message % args
     if DEBUG:
+        if args:
+            message = message % args
         click.echo(message, err=True)
 
 

--- a/starforge/packaging/distutils_commands.py
+++ b/starforge/packaging/distutils_commands.py
@@ -34,16 +34,20 @@ class wheel_info(Command):
 
     description = 'output wheel info'
 
-    user_options = [('yaml', None,
-                     "output YAML"
-                     " (default: false)"),
-                    ('json', None,
-                     "output JSON"
-                     " (default: false)"),
-                    ('pretty', None,
-                     "pretty output"
-                     " (default: false)"),
-                   ]
+    user_options = [
+        ('yaml', None,
+         "output YAML"
+         " (default: false)"),
+        ('json', None,
+         "output JSON"
+         " (default: false)"),
+        ('pretty', None,
+         "pretty output"
+         " (default: false)"),
+        ('output=', None,
+         "output file"
+         " (default: stdout)"),
+    ]
 
     boolean_options = ['yaml', 'json', 'pretty']
 
@@ -51,6 +55,7 @@ class wheel_info(Command):
         self.yaml = False
         self.json = False
         self.pretty = False
+        self.output = None
         self.dump = None
         self.end = ''
 
@@ -78,7 +83,6 @@ class wheel_info(Command):
 
     def run(self):
         bdist_wheel = self.get_finalized_command('bdist_wheel')
-        #bdist_wheel.finalize_options()
         tag = bdist_wheel.get_tag()
         info = {
             'distribution': bdist_wheel.wheel_dist_name,
@@ -93,7 +97,12 @@ class wheel_info(Command):
         }
         for key in DISTRIBUTION_KEYS:
             info[key] = getattr(bdist_wheel.distribution, key)
-        print(self.dump(info), end=self.end)
+        fh = None
+        if self.output:
+            with open(self.output, 'w') as fh:
+                print(self.dump(info), end=self.end, file=fh)
+        else:
+            print(self.dump(info), end=self.end)
 
 
 def dump_human(info):

--- a/starforge/packaging/setup.py
+++ b/starforge/packaging/setup.py
@@ -13,11 +13,20 @@ from os.path import (
 )
 from subprocess import check_output, CalledProcessError
 
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    from backports.tempfile import TemporaryDirectory
+
 from ..io import (
     debug,
     error,
     info,
     warn
+)
+from ..util import (
+    Archive,
+    stringify_cmd
 )
 
 
@@ -99,6 +108,16 @@ def wheel_info(package_dir=None):
 
 
 def _check_output(cmd, cwd=None):
-    debug('Executing in %s: %s', cwd, ' '.join(cmd))
+    debug('Executing in %s: %s', cwd, stringify_cmd(cmd))
     out = check_output(cmd, cwd=cwd)
     return out.decode('UTF-8')
+
+
+class PythonSdist(Archive):
+    @property
+    def wheel_type(self):
+        with TemporaryDirectory(prefix='starforge_sdist_wheel_type_') as td:
+            debug("Extracting '%s' to '%s'", self._arcfile, td)
+            self.extractall(td)
+            root = join(td, self.root)
+            return wheel_type(root)

--- a/starforge/packaging/setup.py
+++ b/starforge/packaging/setup.py
@@ -2,6 +2,7 @@
 """
 import json
 import sys
+import tempfile
 from os import (
     getcwd,
     rename
@@ -88,9 +89,10 @@ def wheel_info(package_dir=None):
     package_dir = package_dir or getcwd()
     wheel_info = None
     try:
-        cmd = [sys.executable, 'setup.py', '-q', 'wheel_info', '--json']
-        wheel_info = _check_output(cmd, cwd=package_dir)
-        wheel_info = json.loads(wheel_info)
+        with tempfile.NamedTemporaryFile(mode='w+') as tfh:
+            cmd = [sys.executable, 'setup.py', '-q', 'wheel_info', '--json', '--output', tfh.name]
+            wheel_info = _check_output(cmd, cwd=package_dir)
+            wheel_info = json.load(tfh)
     except (CalledProcessError, ValueError) as exc:
         error("Failed to get wheel info: %s", exc)
     return wheel_info

--- a/starforge/packaging/setup.py
+++ b/starforge/packaging/setup.py
@@ -11,7 +11,11 @@ from os.path import (
     exists,
     join
 )
-from subprocess import check_output, CalledProcessError
+from subprocess import (
+    CalledProcessError,
+    check_call,
+    check_output
+)
 
 try:
     from tempfile import TemporaryDirectory
@@ -100,14 +104,15 @@ def wheel_info(package_dir=None):
     try:
         with tempfile.NamedTemporaryFile(mode='w+') as tfh:
             cmd = [sys.executable, 'setup.py', '-q', 'wheel_info', '--json', '--output', tfh.name]
-            wheel_info = _check_output(cmd, cwd=package_dir)
+            debug('Executing in %s: %s', package_dir, stringify_cmd(cmd))
+            check_call(cmd, cwd=package_dir)
             wheel_info = json.load(tfh)
     except (CalledProcessError, ValueError) as exc:
         error("Failed to get wheel info: %s", exc)
     return wheel_info
 
 
-def _check_output(cmd, cwd=None):
+def _check_output(cmd, cwd):
     debug('Executing in %s: %s', cwd, stringify_cmd(cmd))
     out = check_output(cmd, cwd=cwd)
     return out.decode('UTF-8')

--- a/starforge/util.py
+++ b/starforge/util.py
@@ -25,20 +25,19 @@ except ImportError:
         import backports.lzma as lzma
     except ImportError:
         lzma = None
-try:
-    from tempfile import TemporaryDirectory
-except ImportError:
-    from backports.tempfile import TemporaryDirectory
 
 try:
     from configparser import ConfigParser, NoSectionError, NoOptionError
 except ImportError:
     from ConfigParser import ConfigParser, NoSectionError, NoOptionError
 
-from six import iteritems, string_types
+from six import (
+    iteritems,
+    string_types
+)
+from six.moves import shlex_quote
 
 from .io import debug
-from .packaging.setup import wheel_type
 
 UNSUPPORTED_ARCHIVE_MESSAGE = "Missing support for '{arctype}' archives, use `pip install starforge[{extra}]` to install"
 
@@ -55,6 +54,12 @@ def dict_merge(old, new):
                 old[k] = v
         else:
             old[k] = v
+
+
+def stringify_cmd(cmd):
+    if isinstance(cmd, string_types):
+        return cmd
+    return ' '.join(map(shlex_quote, cmd))
 
 
 def xdg_config_file(name='config.yml'):
@@ -192,16 +197,6 @@ class Archive(object):
             return asbool(universal)
         except (KeyError, NoSectionError, NoOptionError):
             return False
-
-
-class PythonSdist(Archive):
-    @property
-    def wheel_type(self):
-        with TemporaryDirectory(prefix='starforge_sdist_wheel_type_') as td:
-            debug("Extracting '%s' to '%s'", self._arcfile, td)
-            self.extractall(td)
-            root = join(td, self.root)
-            return wheel_type(root)
 
 
 class UnsupportedArchiveModule(object):


### PR DESCRIPTION
In the `wheel_info.run()` method, the `bdist_wheel = self.get_finalized_command('bdist_wheel')` line can write to stdout, which therefore get prepended to the proper JSON/YAML output of the `wheel_info` command.

Writing the proper output to a temporary file workarounds this problem.

Issue found when adding the pysam 0.15.1 recipe in: https://github.com/galaxyproject/starforge-recipes/pull/30
Failing Travis build: https://travis-ci.org/galaxyproject/starforge-recipes/jobs/477801180