### PR TITLE
Added galaxycloudrunner wheel

### DIFF
--- a/wheels/build/wheels.yml
+++ b/wheels/build/wheels.yml
@@ -222,6 +222,8 @@ purepy_packages:
         version: 3.1.1
     galaxy_sequence_utils:
         version: 1.0.2
+    galaxycloudrunner:
+        version: 0.2.0
     httplib2:
         version: 0.10.3
     idna:


### PR DESCRIPTION
Adds support for galaxycloudrunner, which enables cloud bursting through cloudlaunch+pulsar.
xref: https://galaxycloudrunner.readthedocs.io
xref: https://github.com/galaxyproject/galaxy/pull/7053
xref: https://github.com/galaxyproject/galaxy/pull/7006
xref: https://github.com/galaxyproject/galaxy/pull/6993